### PR TITLE
feat: User 기본 엔티티, id값 -> 엔티티 반환 External 서비스

### DIFF
--- a/src/main/java/com/example/chackchack/domain/user/entity/User.java
+++ b/src/main/java/com/example/chackchack/domain/user/entity/User.java
@@ -1,0 +1,31 @@
+package com.example.chackchack.domain.user.entity;
+
+import com.example.chackchack.common.entity.SoftDeleteEntity;
+import com.example.chackchack.domain.user.enums.UserRole;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends SoftDeleteEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "email", length = 254, nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "password", length = 60, nullable = false)
+    private String password;
+
+    @Column(name = "nickname", length = 30, nullable = false)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_role", nullable = false)
+    private UserRole userRole;
+}

--- a/src/main/java/com/example/chackchack/domain/user/enums/UserRole.java
+++ b/src/main/java/com/example/chackchack/domain/user/enums/UserRole.java
@@ -1,0 +1,6 @@
+package com.example.chackchack.domain.user.enums;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/example/chackchack/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/chackchack/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.example.chackchack.domain.user.repository;
+
+import com.example.chackchack.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/example/chackchack/domain/user/service/UserExternalService.java
+++ b/src/main/java/com/example/chackchack/domain/user/service/UserExternalService.java
@@ -1,0 +1,8 @@
+package com.example.chackchack.domain.user.service;
+
+import com.example.chackchack.domain.user.entity.User;
+
+public interface UserExternalService {
+
+    User findUserByIdOrElseThrow(Long userId);
+}

--- a/src/main/java/com/example/chackchack/domain/user/service/UserExternalServiceImpl.java
+++ b/src/main/java/com/example/chackchack/domain/user/service/UserExternalServiceImpl.java
@@ -1,0 +1,19 @@
+package com.example.chackchack.domain.user.service;
+
+import com.example.chackchack.domain.user.entity.User;
+import com.example.chackchack.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserExternalServiceImpl implements UserExternalService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public User findUserByIdOrElseThrow(Long userId) {
+
+        return userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found"));
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용

- Entity : User
- Enum : UserRole
- Repository : UserRepository
- Service : UserExternalService, UserExternalServiceImpl

만약 다른 도메인에서 external 서비스를 사용해야되는 경우
`private final UserExternalService userExternalService;`처럼 인터페이스만 불러와도 됩니다

## 🔗 연관된 이슈
Related to: #2 #30

<!---- 리뷰 요구사항 (선택) -->
<!---- ex) 다른 도메인에서 참조했을 때 정상적으로 작동하는지 -->

## ✅ PR 유형

- [X] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외