### PR TITLE
feat/ApiPageResponse

### DIFF
--- a/src/main/java/com/example/chackchack/common/dto/response/ApiPageResponse.java
+++ b/src/main/java/com/example/chackchack/common/dto/response/ApiPageResponse.java
@@ -1,0 +1,44 @@
+package com.example.chackchack.common.dto.response;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Getter
+public class ApiPageResponse<T> {
+
+    private final int page;
+    private final int size;
+    private final int totalPages;
+    private final long totalElements;
+    private final List<T> data;
+
+    private ApiPageResponse(int page, int size, int totalPages, long totalElements, List<T> data) {
+        this.page = page;
+        this.size = size;
+        this.totalPages = totalPages;
+        this.totalElements = totalElements;
+        this.data = data;
+    }
+
+    /**
+     * return 200 OK + body(Page 정보 + Page<T>)
+     *
+     * @param pagedData Page<T> 데이터
+     */
+    public static <T>ResponseEntity<ApiPageResponse<T>> ok(Page<T> pagedData) {
+        return ResponseEntity.ok(fromPage(pagedData));
+    }
+
+    private static <T> ApiPageResponse<T> fromPage(Page<T> pagedData) {
+        return new ApiPageResponse<>(
+                pagedData.getPageable().getPageNumber(),
+                pagedData.getPageable().getPageSize(),
+                pagedData.getTotalPages(),
+                pagedData.getTotalElements(),
+                pagedData.getContent()
+        );
+    }
+}


### PR DESCRIPTION
## 📝 작업 내용
단일 데이터가 아닌 페이지 데이터도 공통 응답 형식에 맞게 반환하도록 하는 ApiPageResponse을 구현하였습니다

각 컨트롤러에서 Page로 반환해야 하는 경우
- 반환 타입 : `ResponseEntity<ApiPageResponse<DTO>>`
- `return ApiPageResponse.ok(Page<DTO>);`

## 🔗 연관된 이슈
Related to: #29

## ✅ PR 유형

- [X] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외