### PR TITLE
hotfix: JWT 시크릿키 해결 및 유저 오류 임시 해결

### DIFF
--- a/src/main/java/com/example/chackchack/config/JwtUtil.java
+++ b/src/main/java/com/example/chackchack/config/JwtUtil.java
@@ -9,8 +9,8 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -20,7 +20,6 @@ import java.util.Date;
 
 @Slf4j(topic = "JwtUtil")
 @Component
-@ConfigurationProperties(prefix = "jwt")
 public class JwtUtil {
 
     private static final String BEARER_PREFIX = "Bearer ";

--- a/src/main/java/com/example/chackchack/domain/user/entity/User.java
+++ b/src/main/java/com/example/chackchack/domain/user/entity/User.java
@@ -9,7 +9,8 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@Table(name = "users")
 public class User extends SoftDeleteEntity {
 
     @Id
@@ -28,4 +29,12 @@ public class User extends SoftDeleteEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "user_role", nullable = false)
     private UserRole userRole;
+
+    public User(String email, String password, String nickname, UserRole userRole) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.userRole = userRole;
+    }
+
 }

--- a/src/main/java/com/example/chackchack/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/chackchack/domain/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,4 +14,4 @@ spring:
 
 jwt:
   secret:
-    key: {SECRET_KEY}
+    key: "${SECRET_KEY}"


### PR DESCRIPTION
## 📝 작업 내용
- JWT 시크릿키 오류 해결 : application.yml 수정 (base64형식 입력 권장: `openssl rand -base64 32`)
- User 생성자 access 레밸 수정 및 생성자 추가



## 🔗 연관된 이슈


## ✅ PR 유형

- [ ] 새로운 기능 추가
- [ ] 코드 리팩토링
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외