### PR TITLE
feat : Book의 create,delete,update시에 회원 등급 검증 로직을 추가

### DIFF
--- a/src/main/java/com/example/chackchack/domain/book/controller/BookController.java
+++ b/src/main/java/com/example/chackchack/domain/book/controller/BookController.java
@@ -5,9 +5,11 @@ import com.example.chackchack.common.dto.response.ApiResponse;
 import com.example.chackchack.domain.book.dto.request.BookRequest;
 import com.example.chackchack.domain.book.dto.response.BookResponse;
 import com.example.chackchack.domain.book.service.BookInternalService;
+import com.example.chackchack.domain.common.dto.AuthUser;
+import com.example.chackchack.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -20,9 +22,10 @@ public class BookController {
     private final BookInternalService bookService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<BookResponse>> createBook(@RequestBody BookRequest bookRequest){
+    public ResponseEntity<ApiResponse<BookResponse>> createBook(@AuthenticationPrincipal AuthUser authUser,
+                                                                @RequestBody BookRequest bookRequest){
 
-        BookResponse book = bookService.createBook(bookRequest);
+        BookResponse book = bookService.createBook(authUser,bookRequest);
 
         return ApiResponse.created("도서가 생성되었습니다.",book);
 
@@ -30,9 +33,10 @@ public class BookController {
 
     @PatchMapping("/{bookId}")
     public ResponseEntity<ApiResponse<BookResponse>> updateBook(@RequestBody BookRequest bookRequest,
-                                                   @PathVariable Long bookId){
+                                                                @PathVariable Long bookId,
+                                                                @AuthenticationPrincipal AuthUser authUser){
 
-        BookResponse bookResponse = bookService.updateBook(bookId, bookRequest);
+        BookResponse bookResponse = bookService.updateBook(bookId, bookRequest,authUser);
 
         return ApiResponse.created("도서 정보가 변경되었습니다.", bookResponse);
     }
@@ -56,12 +60,11 @@ public class BookController {
         return ApiResponse.ok(book);
     }
 
-
-
     @DeleteMapping("/{bookId}")
-    public void deleteBook(@PathVariable("bookId") Long bookId){
+    public void deleteBook(@PathVariable("bookId") Long bookId,
+                           @AuthenticationPrincipal AuthUser authuser){
 
-        bookService.deleteBook(bookId);
+        bookService.deleteBook(bookId,authuser);
 
     }
 }

--- a/src/main/java/com/example/chackchack/domain/book/exception/BookErrorCode.java
+++ b/src/main/java/com/example/chackchack/domain/book/exception/BookErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum BookErrorCode implements ErrorCode {
 
-    BOOK_NOT_FOUND("BOOK-001",HttpStatus.NOT_FOUND,"도서를 찾을 수 없습니다.");
+    BOOK_NOT_FOUND("BOOK-001",HttpStatus.NOT_FOUND,"도서를 찾을 수 없습니다."),
+    BOOK_NOT_ALLOWED("BOOK-002",HttpStatus.BAD_REQUEST,"변경 권한이 없습니다.");
 
     private final String code;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/chackchack/domain/book/service/BookInternalService.java
+++ b/src/main/java/com/example/chackchack/domain/book/service/BookInternalService.java
@@ -3,36 +3,58 @@ package com.example.chackchack.domain.book.service;
 import com.example.chackchack.domain.book.dto.request.BookRequest;
 import com.example.chackchack.domain.book.dto.response.BookResponse;
 import com.example.chackchack.domain.book.entity.Book;
+import com.example.chackchack.domain.book.exception.BookErrorCode;
+import com.example.chackchack.domain.book.exception.BookException;
 import com.example.chackchack.domain.book.repository.BookRepository;
+import com.example.chackchack.domain.common.dto.AuthUser;
+import com.example.chackchack.domain.user.entity.User;
+import com.example.chackchack.domain.user.enums.UserRole;
+import com.example.chackchack.domain.user.service.UserExternalService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.example.chackchack.domain.user.enums.UserRole.ROLE_ADMIN;
+
 @Service
 @RequiredArgsConstructor
 public class BookInternalService {
 
+    private final UserExternalService userExternalService;
     private final BookRepository bookRepository;
     private final BookExternalService bookExternalService;
 
-    public BookResponse createBook(BookRequest bookRequest){
+    public BookResponse createBook(AuthUser user,
+                                   BookRequest bookRequest){
 
-        Book book = Book.toEntityFrom(bookRequest);
+        User findUser = userExternalService.findUserByIdOrElseThrow(user.getId());
+        if (!findUser.getUserRole().equals(ROLE_ADMIN)) {
+            throw new BookException(BookErrorCode.BOOK_NOT_ALLOWED);
+        }
 
-        bookRepository.save(book);
+            Book book = Book.toEntityFrom(bookRequest);
 
-        BookResponse response = BookResponse.BookResponseFrom(book);
+            bookRepository.save(book);
 
-        return response;
+            BookResponse response = BookResponse.BookResponseFrom(book);
+
+            return response;
     }
 
     @Transactional
     public BookResponse updateBook(Long bookId,
-                                   BookRequest bookRequest){
+                                   BookRequest bookRequest,
+                                   AuthUser user){
+
+        User findUser = userExternalService.findUserByIdOrElseThrow(user.getId());
+        if (!findUser.getUserRole().equals(ROLE_ADMIN)) {
+            throw new BookException(BookErrorCode.BOOK_NOT_ALLOWED);
+        }
 
         Book book = bookExternalService.findByBookIdOrElseThrow(bookId);
 
@@ -68,7 +90,14 @@ public class BookInternalService {
         return BookResponse.BookResponseFrom(book);
     }
 
-    public void deleteBook(Long Id) {
+    public void deleteBook(Long Id,AuthUser user) {
+
+        User findUser = userExternalService.findUserByIdOrElseThrow(user.getId());
+
+        if (!findUser.getUserRole().equals(ROLE_ADMIN)) {
+            throw new BookException(BookErrorCode.BOOK_NOT_ALLOWED);
+        }
+
         bookRepository.deleteById(Id);
     }
 


### PR DESCRIPTION
## 📝 작업 내용

Book의 create,delete,update시에 회원 등급 검증 로직을 추가해서 ADMIN만 수정이 가능하도록 변경했습니다

admin으로 할시
<img width="1384" height="759" alt="image" src="https://github.com/user-attachments/assets/facbb25c-3ebc-4ff5-9763-cd0c2c376c5c" />

일반 유저일시
<img width="1405" height="665" alt="image" src="https://github.com/user-attachments/assets/720cb1e6-4210-4153-92db-71bf91c7dbbe" />

<img width="1216" height="228" alt="image" src="https://github.com/user-attachments/assets/aacf170b-2a9d-447e-9d7a-b35facf9db9a" />

## 🔗 연관된 이슈
<!---- Related to: #(Isuue Number) -->
#71 

<!---- 리뷰 요구사항 (선택) -->
<!---- ex) 다른 도메인에서 참조했을 때 정상적으로 작동하는지 -->

## ✅ PR 유형

- [X] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외