### PR TITLE
feat: 책 검색 API에 In-memory Cache(Local Memory Cache) 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/chackchack/common/config/CacheConfig.java
+++ b/src/main/java/com/example/chackchack/common/config/CacheConfig.java
@@ -1,0 +1,9 @@
+package com.example.chackchack.common.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+}

--- a/src/main/java/com/example/chackchack/common/config/LocalCacheConfig.java
+++ b/src/main/java/com/example/chackchack/common/config/LocalCacheConfig.java
@@ -1,0 +1,26 @@
+package com.example.chackchack.common.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+import java.util.List;
+
+@Configuration
+public class LocalCacheConfig {
+    @Bean
+    public CacheManager cacheManager() {
+        var searchKeyword = new CaffeineCache("book:search:keyword",
+                Caffeine.newBuilder()
+                        .maximumSize(10_000)
+                        .expireAfterWrite(Duration.ofMinutes(5))
+                        .build());
+        var manager = new SimpleCacheManager();
+        manager.setCaches(List.of(searchKeyword));
+        return manager;
+    }
+}

--- a/src/main/java/com/example/chackchack/domain/book/controller/BookController.java
+++ b/src/main/java/com/example/chackchack/domain/book/controller/BookController.java
@@ -6,7 +6,6 @@ import com.example.chackchack.domain.book.dto.request.BookRequest;
 import com.example.chackchack.domain.book.dto.response.BookResponse;
 import com.example.chackchack.domain.book.service.BookInternalService;
 import com.example.chackchack.domain.common.dto.AuthUser;
-import com.example.chackchack.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,56 +14,66 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/books")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class BookController {
 
     private final BookInternalService bookService;
 
-    @PostMapping
+    @PostMapping("/v1/books")
     public ResponseEntity<ApiResponse<BookResponse>> createBook(@AuthenticationPrincipal AuthUser authUser,
-                                                                @RequestBody BookRequest bookRequest){
+                                                                @RequestBody BookRequest bookRequest) {
 
-        BookResponse book = bookService.createBook(authUser,bookRequest);
+        BookResponse book = bookService.createBook(authUser, bookRequest);
 
-        return ApiResponse.created("도서가 생성되었습니다.",book);
+        return ApiResponse.created("도서가 생성되었습니다.", book);
 
     }
 
-    @PatchMapping("/{bookId}")
+    @PatchMapping("/v1/books/{bookId}")
     public ResponseEntity<ApiResponse<BookResponse>> updateBook(@RequestBody BookRequest bookRequest,
                                                                 @PathVariable Long bookId,
-                                                                @AuthenticationPrincipal AuthUser authUser){
+                                                                @AuthenticationPrincipal AuthUser authUser) {
 
-        BookResponse bookResponse = bookService.updateBook(bookId, bookRequest,authUser);
+        BookResponse bookResponse = bookService.updateBook(bookId, bookRequest, authUser);
 
         return ApiResponse.created("도서 정보가 변경되었습니다.", bookResponse);
     }
 
-    //리스트로 찾기
-    @GetMapping
+    // v1 - 캐시 없음 리스트로 찾기
+    @GetMapping("/v1/books")
     public ResponseEntity<ApiResponse<List<BookResponse>>> findBooks(@RequestParam("keyword") String keyword,
-                                        @RequestParam(defaultValue = "0") int page,
-                                        @RequestParam(defaultValue = "10") int size
-    ){
+                                                                     @RequestParam(defaultValue = "0") int page,
+                                                                     @RequestParam(defaultValue = "10") int size
+    ) {
         List<BookResponse> getBookList = bookService.findBookList(keyword, page, size);
 
         return ApiResponse.ok(getBookList);
     }
 
-    @GetMapping("/{bookId}")
+    // v2 - 캐시 적용 리스트로 찾기
+    @GetMapping("/v2/books")
+    public ResponseEntity<ApiResponse<List<BookResponse>>> findBooksV2(@RequestParam(required = false) String keyword,
+                                                                       @RequestParam(defaultValue = "0") int page,
+                                                                       @RequestParam(defaultValue = "10") int size
+    ) {
+        List<BookResponse> getBookList = bookService.findBookListWithCache(keyword, page, size);
+        return ApiResponse.ok(getBookList);
+    }
+
+    @GetMapping("/v1/books/{bookId}")
     public ResponseEntity<ApiResponse<BookResponse>> findBook(@PathVariable("bookId") Long bookId
-    ){
+    ) {
         BookResponse book = bookService.findBook(bookId);
 
         return ApiResponse.ok(book);
     }
 
-    @DeleteMapping("/{bookId}")
+    @DeleteMapping("/v1/books/{bookId}")
     public void deleteBook(@PathVariable("bookId") Long bookId,
-                           @AuthenticationPrincipal AuthUser authuser){
+                           @AuthenticationPrincipal AuthUser authuser) {
 
-        bookService.deleteBook(bookId,authuser);
+        bookService.deleteBook(bookId, authuser);
 
     }
 }

--- a/src/main/java/com/example/chackchack/domain/book/service/BookInternalService.java
+++ b/src/main/java/com/example/chackchack/domain/book/service/BookInternalService.java
@@ -11,6 +11,7 @@ import com.example.chackchack.domain.search.service.SearchKeywordExternalService
 import com.example.chackchack.domain.user.entity.User;
 import com.example.chackchack.domain.user.service.UserExternalService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -30,6 +31,7 @@ public class BookInternalService {
     private final BookExternalService bookExternalService;
     private final SearchKeywordExternalService searchKeywordExternalService;
 
+    @Transactional
     public BookResponse createBook(AuthUser user,
                                    BookRequest bookRequest) {
 
@@ -70,18 +72,16 @@ public class BookInternalService {
 
 
     // v1 - 캐시 없음
+    @Transactional(readOnly = true)
     public List<BookResponse> findBookList(String keyword,
                                            int page,
                                            int size
     ) {
         Pageable pageRequest = PageRequest.of(page, size);
 
-        // 인기 검색어 저장/업데이트
-        if (keyword != null && !keyword.isBlank()) {
-            searchKeywordExternalService.recordSearch(keyword);
-        }
+        searchKeywordExternalService.recordSearch(keyword);
 
-        Page<Book> bookPage = bookRepository.findByTitleContainingIgnoreCase(keyword, pageRequest);
+        Page<Book> bookPage = bookRepository.findByTitleContainingIgnoreCase(keyword == null ? "" : keyword, pageRequest);
 
         List<BookResponse> bookResponseList = bookPage
                 .stream()
@@ -89,6 +89,28 @@ public class BookInternalService {
                 .toList();
 
         return bookResponseList;
+    }
+
+    // v2 - 캐시 있음
+    @Cacheable(value = "book:search:keyword",
+            key = "#keyword + '_' + #page + '_' + #size",
+            condition = "#page < 10",
+            unless = "#result == null || #result.isEmpty()")
+    @Transactional(readOnly = true)
+    public List<BookResponse> getBookListCached(String keyword, int page, int size) {
+        Pageable pageRequest = PageRequest.of(page, size);
+        Page<Book> bookPage = bookRepository.findByTitleContainingIgnoreCase(
+                keyword == null ? "" : keyword, pageRequest
+        );
+        return bookPage.stream()
+                .map(BookResponse::BookResponseFrom)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<BookResponse> findBookListWithCache(String keyword, int page, int size) {
+        searchKeywordExternalService.recordSearch(keyword);
+        return getBookListCached(keyword, page, size);
     }
 
     public BookResponse findBook(Long bookId) {

--- a/src/main/java/com/example/chackchack/domain/search/entity/SearchKeyword.java
+++ b/src/main/java/com/example/chackchack/domain/search/entity/SearchKeyword.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "search_keyword")
 public class SearchKeyword {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/chackchack/domain/search/service/SearchKeywordExternalServiceImpl.java
+++ b/src/main/java/com/example/chackchack/domain/search/service/SearchKeywordExternalServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.chackchack.domain.search.entity.SearchKeyword;
 import com.example.chackchack.domain.search.repository.SearchKeywordRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -11,14 +12,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class SearchKeywordExternalServiceImpl implements SearchKeywordExternalService {
     private final SearchKeywordRepository searchKeywordRepository;
 
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = false)
     public void recordSearch(String keyword) {
         // 공백 체크
-        if (keyword.isBlank()) return;
+        if (keyword == null || keyword.isBlank()) return;
 
         searchKeywordRepository.findByKeyword(keyword)
                 .ifPresentOrElse(
-                        SearchKeyword::increaseCount,
+                        k -> {
+                            k.increaseCount();
+                            searchKeywordRepository.save(k);
+                        },
                         () -> searchKeywordRepository.save(new SearchKeyword(keyword))
                 );
     }


### PR DESCRIPTION
## 📝 작업 내용
- 책 검색 API에 In-memory Cache(Local Memory Cache) 적용

## 🔗 연관된 이슈
 Related to: #78

## ✅ PR 유형

- [X] 새로운 기능 추가
- [ ] 코드 리팩토링
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 파일 혹은 폴더명 수정 및 삭제
- [ ] 그 외